### PR TITLE
Invokable and next not null

### DIFF
--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -4,10 +4,12 @@ use Zend\Expressive\Helper;
 
 return [
     'dependencies' => [
+        'invokables' => [
+            App\Middleware\TheClacksMiddleware::class => App\Middleware\TheClacksMiddleware::class,
+        ],
         'factories' => [
             Helper\ServerUrlMiddleware::class => Helper\ServerUrlMiddlewareFactory::class,
             Helper\UrlHelperMiddleware::class => Helper\UrlHelperMiddlewareFactory::class,
-            App\Middleware\TheClacksMiddleware::class => Zend\ServiceManager\Factory\InvokableFactory::class,
         ],
     ],
     // This can be used to seed pre- and/or post-routing middleware

--- a/src/App/Middleware/TheClacksMiddleware.php
+++ b/src/App/Middleware/TheClacksMiddleware.php
@@ -6,12 +6,14 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class TheClacksMiddleware
 {
-    public function __invoke(ServerRequestInterface $request, 
-        ResponseInterface $response, 
+    public function __invoke(ServerRequestInterface $request,
+        ResponseInterface $response,
         callable $next = null)
     {
-        $response = $next($request, $response);
-        
+        if ($next) {
+            $response = $next($request, $response);
+        }
+
         return $response->withHeader('X-Clacks-Overhead',['GNU Terry Pratchett']);
     }
 }


### PR DESCRIPTION
Hi @adamculp , 

This is for discussion regarding the invokables vs factories. See we don't really need the `Zend\ServiceManager\Factory\InvokableFactory::class,` . I guess this may help newbie . 

But I am happy to see another way of creating the object. Never used `Zend\ServiceManager` , but Aura.Di :) .

Regarding `$next` it looks a check for is not null is nice.

Thank you.
